### PR TITLE
Fix resize

### DIFF
--- a/js/impress.js
+++ b/js/impress.js
@@ -886,7 +886,7 @@
         // rescale presentation when window is resized
         window.addEventListener("resize", throttle(function () {
             // force going to active step again, to trigger rescaling
-            api.goto( document.querySelector(".active"), 500 );
+            api.goto( document.querySelector(".step.active"), 500 );
         }, 250), false);
         
     }, false);


### PR DESCRIPTION
Fixed Resize: previous code erroneusly select  the active step in case of slides following one with substeps.

In fact due to the fact that (exiting from a slide with substeps) the last substep remains marked as active, the selection of the active step cannot use only the ".active" selector.
